### PR TITLE
Disable lprnet due to import issues

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -37,20 +37,21 @@ vehicle=${1:-true}
 if [ "$vehicle" == "true" ]; then
   echo "Vehicle models will be prepared."
   # download license plate model LPR
-  cd $PROPERTY_LIB_DIR/vehicle/models
-  LICENCE_PLATE_MODEL_DIR="lpdetect"
-  if [ ! -f $PWD/${LICENCE_PLATE_MODEL_DIR}/main.py ]; then
-    echo "Downloading licence plate detection model (LPR) into $PWD."
-    git clone https://github.com/xuexingyu24/License_Plate_Detection_Pytorch.git
-    mv License_Plate_Detection_Pytorch $LICENCE_PLATE_MODEL_DIR
-  else
-    echo "Licence plate detection model (LPR) exists. Skip download."
-  fi
+  # cd $PROPERTY_LIB_DIR/vehicle/models
+  # LICENCE_PLATE_MODEL_DIR="lpdetect"
+  # if [ ! -f $PWD/${LICENCE_PLATE_MODEL_DIR}/main.py ]; then
+  #   echo "Downloading licence plate detection model (LPR) into $PWD."
+  #   git clone https://github.com/xuexingyu24/License_Plate_Detection_Pytorch.git
+  #   mv License_Plate_Detection_Pytorch $LICENCE_PLATE_MODEL_DIR
+  # else
+  #   echo "Licence plate detection model (LPR) exists. Skip download."
+  # fi
+  cd $VQPY_SRC_ROOT
   # install license plate model openalpr
   if python -c "import openalpr" &> /dev/null; then
     echo "Found installed openalpr."
   else
-    pip install openalpr
+    pip install openalpr==1.0
     "Openalpr is installed."
   fi
 fi

--- a/vqpy/property_lib/vehicle/models/lprnet.py
+++ b/vqpy/property_lib/vehicle/models/lprnet.py
@@ -65,8 +65,8 @@ def GetLP(image):
         from lpdetect.LPRNet.LPRNet_Test import decode as lprnet_decode
         from lpdetect.MTCNN.MTCNN import detect_pnet, detect_onet
     except ImportError:
-        raise ImportError("Please run VQPY/download_models.sh before using \
-         built-in vehicle properties.")
+        raise ImportError("Please run vqpy/download_models.sh before using"
+                          " built-in vehicle properties.")
 
     from vqpy.utils import crop_image
 

--- a/vqpy/property_lib/vehicle/vehicle.py
+++ b/vqpy/property_lib/vehicle/vehicle.py
@@ -11,5 +11,7 @@ def license_plate_openalpr(obj, image):
 @vqpy_func_logger(['image'], ['license_plate'], [], required_length=1)
 def license_plate_lprnet(obj, image):
     """recognize license plate using LPRNet"""
-    from vqpy.property_lib.vehicle.models.lprnet import GetLP
-    return [GetLP(image)]
+    raise ValueError("LPRNet for license plate detection is not supported "
+                     "for now. Please use 'openalpr' instead.")
+    # from vqpy.property_lib.vehicle.models.lprnet import GetLP
+    # return [GetLP(image)]


### PR DESCRIPTION
## Why this change?

Disable LPRNet for license plate detection due to below issues.
1. Files in lprnet use relative import like `from model.LPRNet` ([link](https://github.com/xuexingyu24/License_Plate_Detection_Pytorch/blob/master/LPRNet/LPRNet_Test.py#L12)). It can be messed up with the imports in vqpy. 
2. It might be hard to add LPRNet and other repository into `sys.path` with a relative path, since we are not sure about user's working directory. 

## What does this PR include?
* remove lprnet from `download_models.sh`
* raise error if user specifies lprnet as license plate detection model
* fix openalpr model into 1.0. There are bugs in version 1.1 ("'Alpr' object has no attribute 'loaded' ")

## User API changes
Can only use `self.infer('license_plate', {'license_plate': 'openalpr'})` instead of `self.infer('license_plate', {'license_plate': 'lprnet'})`

## How did I test the PR?
With red moving car example

## New dependencies included
- [ ] I have added the dependencies in `setup.py`
