### PR TITLE
Fix path to version.txt in get_version()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 
 def get_version() -> str:
-    root = Path(__file__).parent.parent
+    root = Path(__file__).parent
     return open(root / "version.txt", "r").read().strip()
 
 


### PR DESCRIPTION
## Why this change?
With folder structure
```text
.
├── setup.py
├── version.txt
...
```

`get_version` in `setup.py` should set `root` to `Path(__file__).parent` (instead of `Path(__file__).parent.parent`) before referencing `version.txt` with `root / "version.txt"`.

## What does this PR include?
Change `root=Path(__file__).parent.parent` to `root=Path(__file__).parent`

## User API changes
N/A

## How did I test the PR?
Run `pip install -e .`, test install is working

## New dependencies included
None
