### PR TITLE
Fix detector setup

### DIFF
--- a/vqpy/operator/detector/__init__.py
+++ b/vqpy/operator/detector/__init__.py
@@ -51,7 +51,7 @@ register("yolov4", Yolov4Detector, yolov4_path, None)
 
 def setup_detector(cls_names,
                    detector_name: Optional[str] = None,
-                   detector_args: Optional[dict] = None
+                   detector_args: Optional[dict] = dict()
                    ) -> (str, DetectorBase):
     """setup a detector for video analytics
     cls_names: the detection class types of the required detector


### PR DESCRIPTION
## Why this change?
Default value of `detector_args` should be empty dict

## What does this PR include?
Change default value of `detector_args` to `dict()`
## User API changes
None
## How did I test the PR?
Run test loitering
## New dependencies included
N/A