### PR TITLE
fuzzy compare and reuse code in end to end tests

### DIFF
--- a/examples/fall_detection/main.py
+++ b/examples/fall_detection/main.py
@@ -47,7 +47,7 @@ class Person(vqpy.VObjBase):
         tlbr = self.getv('tlbr')
         if tlbr is None:
             return None
-        return Person.pose_model.predict(image, torch.tensor([tlbr]))
+        return Person.pose_model.predict(image, torch.tensor(np.array([tlbr])))
 
     @vqpy.property()
     def pose(self) -> str:

--- a/test/e2e_tests/conftest.py
+++ b/test/e2e_tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+from pathlib import Path
+import sys
+
+root = Path(__file__).parent.parent.parent
+example_path = (root / "examples/").as_posix()
+fall_detection_lib_path = (root / "Human-Falling-Detect-Tracks").as_posix()
+
+
+@pytest.fixture
+def setup_example_path():
+    sys.path.append(example_path)
+    yield
+    sys.path.remove(example_path)
+
+
+@pytest.fixture
+def setup_fall_detection_lib_path():
+    sys.path.append(fall_detection_lib_path)
+    yield
+    sys.path.remove(fall_detection_lib_path)

--- a/test/e2e_tests/conftest.py
+++ b/test/e2e_tests/conftest.py
@@ -4,7 +4,6 @@ import sys
 
 root = Path(__file__).parent.parent.parent
 example_path = (root / "examples/").as_posix()
-fall_detection_lib_path = (root / "Human-Falling-Detect-Tracks").as_posix()
 
 
 @pytest.fixture
@@ -12,10 +11,3 @@ def setup_example_path():
     sys.path.append(example_path)
     yield
     sys.path.remove(example_path)
-
-
-@pytest.fixture
-def setup_fall_detection_lib_path():
-    sys.path.append(fall_detection_lib_path)
-    yield
-    sys.path.remove(fall_detection_lib_path)

--- a/test/e2e_tests/e2e.py
+++ b/test/e2e_tests/e2e.py
@@ -2,7 +2,7 @@
 from typing import Dict, List
 import pickle
 import json
-import logging
+import warnings
 
 from vqpy.operator.detector.base import DetectorBase
 from vqpy.class_names.coco import COCO_CLASSES
@@ -66,4 +66,7 @@ def compare(result_path, expected_result_path, tolerance=0.1):
     ), f"mismatched {mismatch_cnt} frames > {len(result)*tolerance} tolerance"
 
     if mismatch_cnt > 0:
-        logging.warning(f"mismatched {mismatch_cnt} frames")
+        warnings.warn(
+            f"compare result {result_path} to expected {expected_result_path},"
+            f" mismatched {mismatch_cnt} frames"
+        )

--- a/test/e2e_tests/e2e.py
+++ b/test/e2e_tests/e2e.py
@@ -2,6 +2,7 @@
 from typing import Dict, List
 import pickle
 import json
+import logging
 
 from vqpy.operator.detector.base import DetectorBase
 from vqpy.class_names.coco import COCO_CLASSES
@@ -25,20 +26,44 @@ class FakeYOLOX(DetectorBase):
 
 
 # compare results
-def compare(result_path, expected_result_path):
+def compare(result_path, expected_result_path, tolerance=0.1):
     with open(result_path, "r") as f:
         result = json.load(f)
     with open(expected_result_path, "r") as f:
         expected = json.load(f)
-    assert len(result) == len(
-        expected
-    ), f"result length error, {len(result)} present, expect {len(expected)}"
-    for i in range(len(result)):
-        assert (
-            result[i]["frame_id"] == expected[i]["frame_id"]
-        ), f"{i}th entry has frame_id {result[i]['frame_id']}, \
-        expect {expected[i]['frame_id']}"
-        assert (
-            result[i]["data"] == expected[i]["data"]
-        ), f"frame {result[i]['frame_id']} has data {result[i]['data']},\
-            expect {expected[i]['data']}"
+
+    # allow some mismatch
+    assert abs(len(result) - len(expected)) < len(result) * tolerance, (
+        f"result length error, {len(result)} present, expect {len(expected)},"
+        f" difference {abs(len(result) - len(expected))} > tolerance"
+        f" {len(result)*tolerance}"
+    )
+
+    mismatch_cnt = 0
+    result_it = 0
+    expected_it = 0
+    while result_it < len(result) and expected_it < len(expected):
+        if result[result_it]["frame_id"] < expected[expected_it]["frame_id"]:
+            result_it += 1
+            mismatch_cnt += 1
+        elif result[result_it]["frame_id"] > expected[expected_it]["frame_id"]:
+            expected_it += 1
+            mismatch_cnt += 1
+        else:
+            assert (
+                result[result_it]["data"] == expected[expected_it]["data"]
+            ), (
+                f"frame {result[result_it]['frame_id']} has data"
+                f" {result[result_it]['data']}, expect"
+                f" {expected[expected_it]['data']}"
+            )
+            result_it += 1
+            expected_it += 1
+
+    mismatch_cnt += (len(result) - result_it) + (len(expected) - expected_it)
+    assert (
+        mismatch_cnt < len(result) * tolerance
+    ), f"mismatched {mismatch_cnt} frames > {len(result)*tolerance} tolerance"
+
+    if mismatch_cnt > 0:
+        logging.warning(f"mismatched {mismatch_cnt} frames")

--- a/test/e2e_tests/test_fall_detection.py
+++ b/test/e2e_tests/test_fall_detection.py
@@ -44,7 +44,7 @@ class Person(vqpy.VObjBase):
         tlbr = self.getv("tlbr")
         if tlbr is None:
             return None
-        return Person.pose_model.predict(image, torch.tensor([tlbr]))
+        return Person.pose_model.predict(image, torch.tensor(np.array([tlbr])))
 
     @vqpy.property()
     def pose(self) -> str:
@@ -87,6 +87,7 @@ def test_fall_detection():
 
     from PoseEstimateLoader import SPPE_FastPose  # noqa: E402
     from ActionsEstLoader import TSSTG  # noqa: E402
+
     register(fake_detector_name, FakeYOLOX, precomputed_path, None)
     pose_model = SPPE_FastPose(
         backbone="resnet50",

--- a/test/e2e_tests/test_fall_detection.py
+++ b/test/e2e_tests/test_fall_detection.py
@@ -1,7 +1,9 @@
+import pytest
 from pathlib import Path
 import torch
 import numpy as np
 import random
+import sys
 
 import vqpy
 from vqpy.operator.detector import register
@@ -22,6 +24,15 @@ result_path = (
 expected_result_path = (
     root / f"expected_results/{video_name}_{task_name}_yolox.json"
 ).as_posix()
+
+fall_detection_lib_path = (root / "Human-Falling-Detect-Tracks").as_posix()
+
+
+@pytest.fixture
+def setup_fall_detection_lib_path():
+    sys.path.append(fall_detection_lib_path)
+    yield
+    sys.path.remove(fall_detection_lib_path)
 
 
 def test_fall_detection(setup_example_path, setup_fall_detection_lib_path):

--- a/test/e2e_tests/test_fall_detection.py
+++ b/test/e2e_tests/test_fall_detection.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import torch
 import numpy as np
 import random
-import sys
 
 import vqpy
 from vqpy.operator.detector import register
@@ -24,67 +23,15 @@ expected_result_path = (
     root / f"expected_results/{video_name}_{task_name}_yolox.json"
 ).as_posix()
 
-fall_detection_lib_path = (root / "Human-Falling-Detect-Tracks").as_posix()
-sys.path.append(fall_detection_lib_path)
 
-
-class Person(vqpy.VObjBase):
-    required_fields = ["class_id", "tlbr"]
-
-    # default values, to be assigned in main()
-    pose_model = None
-    action_model = None
-
-    @vqpy.property()
-    @vqpy.stateful(30)
-    def keypoints(self):
-        # per-frame property, but tracker can return objects
-        # not in the current frame
-        image = self._ctx.frame
-        tlbr = self.getv("tlbr")
-        if tlbr is None:
-            return None
-        return Person.pose_model.predict(image, torch.tensor(np.array([tlbr])))
-
-    @vqpy.property()
-    def pose(self) -> str:
-        keypoints_list = []
-        for i in range(-self._track_length, 0):
-            keypoint = self.getv("keypoints", i)
-            if keypoint is not None:
-                keypoints_list.append(keypoint)
-            if len(keypoints_list) >= 30:
-                break
-        if len(keypoints_list) < 30:
-            return "unknown"
-        pts = np.array(keypoints_list, dtype=np.float32)
-        out = Person.action_model.predict(pts, self._ctx.frame.shape[:2])
-        action_name = Person.action_model.class_names[out[0].argmax()]
-        return action_name
-
-
-class FallDetection(vqpy.QueryBase):
-    """The class obtaining all fallen person"""
-
-    @staticmethod
-    def setting() -> vqpy.VObjConstraint:
-        filter_cons = {
-            "__class__": lambda x: x == Person,
-            "pose": lambda x: x == "Fall Down",
-        }
-        select_cons = {"track_id": None, "tlbr": lambda x: str(x)}
-        return vqpy.VObjConstraint(
-            filter_cons=filter_cons, select_cons=select_cons, filename="fall"
-        )
-
-
-def test_fall_detection():
+def test_fall_detection(setup_example_path, setup_fall_detection_lib_path):
     # avoid randomness
     torch.use_deterministic_algorithms(True)
     torch.manual_seed(0)
     np.random.seed(0)
     random.seed(0)
 
+    from fall_detection.main import Person, FallDetection  # noqa: E402
     from PoseEstimateLoader import SPPE_FastPose  # noqa: E402
     from ActionsEstLoader import TSSTG  # noqa: E402
 

--- a/test/e2e_tests/test_loitering.py
+++ b/test/e2e_tests/test_loitering.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 
 import vqpy
 from vqpy.class_names.coco import COCO_CLASSES
@@ -22,41 +23,9 @@ expected_result_path = (
 ).as_posix()
 
 
-class Person(vqpy.VObjBase):
-    pass
+def test_loitering(setup_example_path):
+    from loitering.main import Person, People_loitering_query  # noqa: E402
 
-
-class People_loitering_query(vqpy.QueryBase):
-    @staticmethod
-    def setting() -> vqpy.VObjConstraint:
-        REGION = [
-            (550, 550),
-            (1162, 400),
-            (1720, 720),
-            (1430, 1072),
-            (600, 1073),
-        ]
-        REGIONS = [REGION]
-
-        filter_cons = {
-            "__class__": lambda x: x == Person,
-            "bottom_center": vqpy.query.continuing(
-                condition=vqpy.query.utils.within_regions(REGIONS),
-                duration=10,
-                name="in_roi",
-            ),
-        }
-        select_cons = {
-            "track_id": None,
-            "coordinate": lambda x: str(x),
-            "in_roi_periods": None,
-        }
-        return vqpy.VObjConstraint(
-            filter_cons, select_cons, filename="loitering"
-        )
-
-
-def test_loitering():
     register(fake_detector_name, FakeYOLOX, precomputed_path, None)
     vqpy.launch(
         cls_name=COCO_CLASSES,

--- a/test/e2e_tests/test_loitering.py
+++ b/test/e2e_tests/test_loitering.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import sys
 
 import vqpy
 from vqpy.class_names.coco import COCO_CLASSES

--- a/test/e2e_tests/test_unattended_baggage.py
+++ b/test/e2e_tests/test_unattended_baggage.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 
 import vqpy
 from vqpy.class_names.coco import COCO_CLASSES
@@ -22,75 +23,13 @@ expected_result_path = (
 ).as_posix()
 
 
-def distance(vobj1_tlbr, vobj2_tlbr):
-    from math import sqrt
-    center1 = (vobj1_tlbr[:2] + vobj1_tlbr[2:]) / 2
-    center2 = (vobj2_tlbr[:2] + vobj2_tlbr[2:]) / 2
-    # difference between center coordinate
-    diff = center2 - center1
-    return sqrt(diff[0]**2 + diff[1]**2)
+def test_unattended_baggage(setup_example_path):
+    from unattended_baggage.main import (
+        Person,
+        Baggage,
+        FindUnattendedBaggage,
+    )  # noqa: E402
 
-
-class Person(vqpy.VObjBase):
-    pass
-
-
-class Baggage(vqpy.VObjBase):
-    @vqpy.stateful(length=2)
-    @vqpy.cross_vobj_property(
-        vobj_type=Person, vobj_num="ALL",
-        vobj_input_fields=("track_id", "tlbr")
-    )
-    # function decorator responsible for retrieving list of properties
-    # Person_id and Person_tlbr given as a list of track_id's and tlbr's
-    def owner(self, person_ids_tlbrs):
-        # if previous owner within distance, return previous owner track id
-        # else: find the nearest person within distance, return the track id
-        # else: return None
-        baggage_tlbr = self.getv('tlbr')
-        prev_owner = self.getv('owner', -2)
-        owner_id = None
-        # with new implementation of @cross_vobj_property and VObj.update, only
-        # tracked VObjs will go into the filter and compute property "owner"
-        # Thus no need to handle situation of baggage_tlbr being None
-
-        # set threshold to baggage's width
-        threshold = (baggage_tlbr[3] - baggage_tlbr[1])
-        min_dist = threshold + 1
-        for person_id, person_tlbr in person_ids_tlbrs:
-            dist = distance(baggage_tlbr, person_tlbr)
-            if person_id == prev_owner and dist <= threshold:
-                # return previous owner if still around
-                return prev_owner
-            if dist <= threshold and dist < min_dist:
-                owner_id = person_id
-                min_dist = dist
-        # new owner is returned (will return None if owner not found)
-        return owner_id
-
-
-class FindUnattendedBaggage(vqpy.QueryBase):
-    @staticmethod
-    def setting() -> vqpy.VObjConstraint:
-        filter_cons = {
-            "__class__": lambda x: x == Baggage,
-            "owner": vqpy.query.continuing(
-                condition=lambda x: x is None, duration=10, name="no_owner"
-            ),
-        }
-        select_cons = {
-            "track_id": None,
-            "tlbr": lambda x: str(x),
-            "no_owner_periods": None,
-        }
-        return vqpy.VObjConstraint(
-            filter_cons=filter_cons,
-            select_cons=select_cons,
-            filename="unattended_baggage",
-        )
-
-
-def test_unattended_baggage():
     register(fake_detector_name, FakeYOLOX, precomputed_path, None)
     vqpy.launch(
         cls_name=COCO_CLASSES,

--- a/test/e2e_tests/test_unattended_baggage.py
+++ b/test/e2e_tests/test_unattended_baggage.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import sys
 
 import vqpy
 from vqpy.class_names.coco import COCO_CLASSES

--- a/vqpy/operator/tracker/byte_tracker.py
+++ b/vqpy/operator/tracker/byte_tracker.py
@@ -23,14 +23,14 @@ class ByteTracker(GroundTrackerBase):
             self.track_id = self.next_id()
             # TODO: remove unnecessary track_id assignments
             self.data = data
-            self._tlbr = np.asarray(data["tlbr"], dtype=np.float)
+            self._tlbr = np.asarray(data["tlbr"], dtype=float)
             self.score = data["score"]
 
             self.is_activated = False
             self.tracklet_len = 0
 
         def set_tlbr(self, tlbr):
-            self._tlbr = np.asarray(tlbr, dtype=np.float)
+            self._tlbr = np.asarray(tlbr, dtype=float)
 
         def initiate(self, frame_id):
             """Initiate a VObj, so that it have tracking property

--- a/vqpy/operator/tracker/matching.py
+++ b/vqpy/operator/tracker/matching.py
@@ -61,13 +61,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -125,17 +125,17 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
     det_features = np.asarray([track.curr_feat for track in detections],
-                              dtype=np.float)
+                              dtype=float)
     # for i, track in enumerate(tracks):
     #     cost_matrix[i, :] = np.maximum(0.0,
     #                                    cdist(track.smooth_feat.reshape(1,-1),
     #                                    det_features, metric))
     track_features = np.asarray([track.smooth_feat for track in tracks],
-                                dtype=np.float)
+                                dtype=float)
     # Nomalized features
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))
     return cost_matrix


### PR DESCRIPTION
## What does this PR include?
Allow some mismatch between computed and expected results in end to end tests. Mainly for fall detection example, where indeterministic models are used during filtering.

Import `VObjs` and queries used in end to end tests from example scripts.

## User API changes
None

## How did I test the PR?
Re-run all end to end tests.

## New dependencies included
None