### PR TITLE
Fix hist_len in vobj property dependencies

### DIFF
--- a/test/unit_tests/backend/operator/test_vobj_projector.py
+++ b/test/unit_tests/backend/operator/test_vobj_projector.py
@@ -143,7 +143,7 @@ def test_stateful_projector(tracker):
         prev=tracker,
         condition_func="person",
     )
-    hist_len = 2
+    hist_len = 1
 
     projector = VObjProjector(
         prev=person_vobj_filter,
@@ -159,7 +159,7 @@ def test_stateful_projector(tracker):
             track_id = vobj.get("track_id")
             if track_id:
                 checked = True
-                if frame.id < hist_len - 1:
+                if frame.id < hist_len:
                     assert vobj["hist_tlbr"] is None
                 else:
                     assert vobj["hist_tlbr"] is not None
@@ -228,7 +228,7 @@ def test_stateful_projector_image_video(tracker):
         prev=tracker,
         condition_func="person",
     )
-    hist_len = 2
+    hist_len = 1
 
     projector = VObjProjector(
         prev=person_vobj_filter,
@@ -240,10 +240,11 @@ def test_stateful_projector_image_video(tracker):
     num_image_cropped = 0
     while projector.has_next():
         frame = projector.next()
+
         for vobj in frame.vobj_data["person"]:
             track_id = vobj.get("track_id")
             if track_id:
-                if frame.id < hist_len - 1:
+                if frame.id < hist_len:
                     assert vobj["image_fps_stateful"] is None
                 else:
                     result = vobj["image_fps_stateful"]

--- a/test/unit_tests/backend/plan/run_plan.py
+++ b/test/unit_tests/backend/plan/run_plan.py
@@ -30,7 +30,7 @@ class Vehicle(VObjBase):
         else:
             return "XYZ789"
 
-    @vobj_property(inputs={"tlbr": 2})
+    @vobj_property(inputs={"tlbr": 1})
     def velocity(self, values):
         fps = 24.0
         last_tlbr, tlbr = values["tlbr"]

--- a/test/unit_tests/backend/plan/run_plan_person.py
+++ b/test/unit_tests/backend/plan/run_plan_person.py
@@ -26,7 +26,7 @@ class Person(VObjBase):
         assert len(tlbr) == 4
         return (tlbr[:2] + tlbr[2:]) / 2
 
-    @vobj_property(inputs={"tlbr": 2})
+    @vobj_property(inputs={"tlbr": 1})
     def velocity(self, values):
         fps = 24.0
         last_tlbr, tlbr = values["tlbr"]
@@ -39,7 +39,7 @@ class Person(VObjBase):
         dcenter = (cur_center - last_center) / scale * fps
         return math.sqrt(sum(dcenter * dcenter))
 
-    @vobj_property(inputs={"velocity": 2})
+    @vobj_property(inputs={"velocity": 1})
     def acceleration(self, values):
         fps = 24.0
         last_velocity, velocity = values["velocity"]


### PR DESCRIPTION
## Why this change?
Now: 
history length is 1. And `values` include 1 past frame data and current frame data. 
```
    @vobj_property(inputs={"tlbr": 1}) 
    def velocity(self, values):
```


## What does this PR include?

## User API changes

## How did I test the PR?

## New dependencies included
- [ ] I have added the dependencies in `setup.py`
