### PR TITLE
change np.float to np.float_ according to numpy update

### DIFF
--- a/vqpy/operator/detector/models/onnx/yolov4.py
+++ b/vqpy/operator/detector/models/onnx/yolov4.py
@@ -58,7 +58,7 @@ def postprocess(detections, image_size):
             xy_grid = np.expand_dims(np.stack(xy_grid, axis=-1), axis=2)
 
             xy_grid = np.tile(np.expand_dims(xy_grid, axis=0), [1, 1, 1, 3, 1])
-            xy_grid = xy_grid.astype(np.float)
+            xy_grid = xy_grid.astype(np.float_)
 
             pred_xy = ((special.expit(conv_raw_dxdy) * XYSCALE[i]) -
                        0.5 * (XYSCALE[i] - 1) + xy_grid) * STRIDES[i]


### PR DESCRIPTION
## Why this change?
`np.float` is deprecated in NumPy 1.20. Change it to `np.float_` according to this [document](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations).

## What does this PR include?

## User API changes

## How did I test the PR?

## New dependencies included
- In `setup.py` we have `numpy<1.24.0`, which seems OK.
