### PR TITLE
Move filter to adjacent to corresponding projector

### DIFF
--- a/test/unit_tests/backend/plan/run_plan_person.py
+++ b/test/unit_tests/backend/plan/run_plan_person.py
@@ -85,16 +85,20 @@ class ListPerson(QueryBase):
 
 
 def test_plan():
-    planner = Planner()
-    launch_args = {
-        "video_path": video_path,
-    }
-    root_plan_node = planner.parse(ListPerson())
-    planner.print_plan(root_plan_node)
-    executor = Executor(root_plan_node, launch_args)
-    result = executor.execute()
-    for res in result:
-        print(res)
+    # planner = Planner()
+    # launch_args = {
+    #     "video_path": video_path,
+    # }
+    # root_plan_node = planner.parse(ListPerson())
+    # planner.print_plan(root_plan_node)
+    # executor = Executor(root_plan_node, launch_args)
+    # result = executor.execute()
+    # for res in result:
+    #     print(res)
+    query_executor = vqpy.init(video_path=video_path,
+                               query_obj=ListPerson(),
+                               output_per_frame_results=False)
+    vqpy.run(query_executor)
 
 
 def test_customize_video_reader():

--- a/test/unit_tests/backend/plan/run_plan_person.py
+++ b/test/unit_tests/backend/plan/run_plan_person.py
@@ -8,6 +8,8 @@ import fake_yolox  # noqa F401
 import numpy as np
 import math
 import vqpy
+import time
+
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 resource_dir = os.path.join(current_dir, "..", "..", "resources/")
@@ -43,6 +45,7 @@ class Person(VObjBase):
 
     @vobj_property(inputs={"velocity": 1})
     def acceleration(self, values):
+        time.sleep(0.005)
         fps = 24.0
         last_velocity, velocity = values["velocity"]
         if last_velocity is None or velocity is None:
@@ -68,8 +71,8 @@ class ListPerson(QueryBase):
         return (
             (self.person.score > 0.6)
             & (self.person.score < 0.7)
+            & (self.person.velocity < 1.0)
             & (self.person.acceleration > 0)
-            | (self.person.over_speed == True)  # noqa: E712
         )
 
     def frame_output(self):
@@ -136,6 +139,7 @@ def test_customize_video_reader():
 
 
 if __name__ == "__main__":
+    st = time.time()
     test_plan()
-    print("test_plan passed")
+    print(f"test_plan takes {time.time() - st:.2f} seconds")
     # result = test_customize_video_reader()

--- a/test/unit_tests/backend/plan/run_plan_person.py
+++ b/test/unit_tests/backend/plan/run_plan_person.py
@@ -1,6 +1,4 @@
 from typing import Dict
-from vqpy.backend.executor import Executor
-from vqpy.backend.planner import Planner
 from vqpy.frontend.vobj import VObjBase, vobj_property
 from vqpy.frontend.query import QueryBase
 import os

--- a/vqpy/backend/plan_nodes/vobj_filter.py
+++ b/vqpy/backend/plan_nodes/vobj_filter.py
@@ -18,7 +18,6 @@ class VObjFilterNode(AbstractPlanNode):
             prev=self.prev.to_operator(lauch_args),
             condition_func=self.predicate.generate_condition_function(),
             filter_index=self.filter_index
-
         )
 
     def __str__(self):
@@ -40,9 +39,16 @@ def create_vobj_class_filter_node(query_obj: QueryBase, input_node):
     return node
 
 
-def create_vobj_filter_node(query_obj: QueryBase, input_node):
+def create_vobj_filter_node_pred(predicate: Predicate, input_node):
+    output_node = input_node
+    output_node = output_node.set_next(
+        VObjFilterNode(predicate=predicate, filter_index=0))
+    return output_node
+
+
+def create_vobj_filter_node_query(query_obj: QueryBase, input_node):
     predicate = query_obj.frame_constraint()
 
-    output_node = input_node.set_next(
-        VObjFilterNode(predicate=predicate, filter_index=0))
+    output_node = create_vobj_filter_node_pred(predicate, input_node)
+
     return output_node

--- a/vqpy/backend/planner.py
+++ b/vqpy/backend/planner.py
@@ -6,11 +6,12 @@ from vqpy.backend.plan_nodes.output_formatter import (
 from vqpy.backend.plan_nodes.tracker import create_tracker_node
 from vqpy.backend.plan_nodes.vobj_filter import (
     create_vobj_class_filter_node,
-    create_vobj_filter_node,
+    create_vobj_filter_node_query,
 )
 from vqpy.backend.plan_nodes.vobj_projector import (
     create_frame_output_projector,
     create_pre_filter_projector,
+    create_projector_adjacent_to_filter
 )
 from vqpy.backend.plan_nodes.base import AbstractPlanNode
 from vqpy.backend.plan_nodes.object_detector import create_object_detector_node
@@ -39,8 +40,12 @@ class Planner:
         output_node = create_object_detector_node(query_obj, input_node)
         output_node = create_tracker_node(query_obj, output_node)
         output_node = create_vobj_class_filter_node(query_obj, output_node)
-        output_node, map = create_pre_filter_projector(query_obj, output_node)
-        output_node = create_vobj_filter_node(query_obj, output_node)
+        # code for first all projectors then all filters
+        # output_node, map = create_pre_filter_projector(query_obj, output_node)
+        # output_node = create_vobj_filter_node_query(query_obj, output_node)
+        output_node, map = create_projector_adjacent_to_filter(
+            query_obj, output_node
+        )
         if not output_per_frame_results:
             # Todo: add bypass to output formatter when
             # output_per_frame_results is True.

--- a/vqpy/backend/planner.py
+++ b/vqpy/backend/planner.py
@@ -6,11 +6,11 @@ from vqpy.backend.plan_nodes.output_formatter import (
 from vqpy.backend.plan_nodes.tracker import create_tracker_node
 from vqpy.backend.plan_nodes.vobj_filter import (
     create_vobj_class_filter_node,
-    create_vobj_filter_node_query,  # noqa: F401
+    # create_vobj_filter_node_query,  
 )
 from vqpy.backend.plan_nodes.vobj_projector import (
     create_frame_output_projector,
-    create_pre_filter_projector,   # noqa: F401
+    # create_pre_filter_projector, 
     create_projector_adjacent_to_filter
 )
 from vqpy.backend.plan_nodes.base import AbstractPlanNode

--- a/vqpy/backend/planner.py
+++ b/vqpy/backend/planner.py
@@ -6,11 +6,11 @@ from vqpy.backend.plan_nodes.output_formatter import (
 from vqpy.backend.plan_nodes.tracker import create_tracker_node
 from vqpy.backend.plan_nodes.vobj_filter import (
     create_vobj_class_filter_node,
-    create_vobj_filter_node_query, # noqa: F401
+    create_vobj_filter_node_query,  # noqa: F401
 )
 from vqpy.backend.plan_nodes.vobj_projector import (
     create_frame_output_projector,
-    create_pre_filter_projector,  # noqa: F401
+    create_pre_filter_projector,   # noqa: F401
     create_projector_adjacent_to_filter
 )
 from vqpy.backend.plan_nodes.base import AbstractPlanNode
@@ -41,7 +41,7 @@ class Planner:
         output_node = create_tracker_node(query_obj, output_node)
         output_node = create_vobj_class_filter_node(query_obj, output_node)
         # code for first all projectors then all filters
-        # output_node, map = create_pre_filter_projector(query_obj, 
+        # output_node, map = create_pre_filter_projector(query_obj,
         #    output_node)
         # output_node = create_vobj_filter_node_query(query_obj, output_node)
         output_node, map = create_projector_adjacent_to_filter(

--- a/vqpy/backend/planner.py
+++ b/vqpy/backend/planner.py
@@ -6,11 +6,11 @@ from vqpy.backend.plan_nodes.output_formatter import (
 from vqpy.backend.plan_nodes.tracker import create_tracker_node
 from vqpy.backend.plan_nodes.vobj_filter import (
     create_vobj_class_filter_node,
-    # create_vobj_filter_node_query,  
+    # create_vobj_filter_node_query,
 )
 from vqpy.backend.plan_nodes.vobj_projector import (
     create_frame_output_projector,
-    # create_pre_filter_projector, 
+    # create_pre_filter_projector,
     create_projector_adjacent_to_filter
 )
 from vqpy.backend.plan_nodes.base import AbstractPlanNode

--- a/vqpy/backend/planner.py
+++ b/vqpy/backend/planner.py
@@ -6,11 +6,11 @@ from vqpy.backend.plan_nodes.output_formatter import (
 from vqpy.backend.plan_nodes.tracker import create_tracker_node
 from vqpy.backend.plan_nodes.vobj_filter import (
     create_vobj_class_filter_node,
-    create_vobj_filter_node_query,
+    create_vobj_filter_node_query, # noqa: F401
 )
 from vqpy.backend.plan_nodes.vobj_projector import (
     create_frame_output_projector,
-    create_pre_filter_projector,
+    create_pre_filter_projector,  # noqa: F401
     create_projector_adjacent_to_filter
 )
 from vqpy.backend.plan_nodes.base import AbstractPlanNode
@@ -41,7 +41,8 @@ class Planner:
         output_node = create_tracker_node(query_obj, output_node)
         output_node = create_vobj_class_filter_node(query_obj, output_node)
         # code for first all projectors then all filters
-        # output_node, map = create_pre_filter_projector(query_obj, output_node)
+        # output_node, map = create_pre_filter_projector(query_obj, 
+        #    output_node)
         # output_node = create_vobj_filter_node_query(query_obj, output_node)
         output_node, map = create_projector_adjacent_to_filter(
             query_obj, output_node

--- a/vqpy/frontend/vobj/property.py
+++ b/vqpy/frontend/vobj/property.py
@@ -60,6 +60,7 @@ class BuiltInProperty(Property):
     def __str__(self):
         return f"BuiltInProperty(name={self.name})"
 
+
 class Literal(Property):
     def __init__(self, value):
         self.value = value

--- a/vqpy/frontend/vobj/property.py
+++ b/vqpy/frontend/vobj/property.py
@@ -57,6 +57,8 @@ class BuiltInProperty(Property):
     def get_vobjs(self):
         return {self.vobj}
 
+    def __str__(self):
+        return f"BuiltInProperty(name={self.name})"
 
 class Literal(Property):
     def __init__(self, value):


### PR DESCRIPTION
## Why this change?
Move the filters to the corresponding projectors for acceleration 
 Note that this PR only moves the filters which have the corresponding projectors for property computation. All filters for the built-in properties are still put at the end. 
 

## What does this PR include?
1. add two methods to `Predicate` for retrieving the property names included.
2. add function in `plan_node/vobj_filter` which move the filter to the projector

## User API changes
None

## How did I test the PR?
With `test/unit_tests/backend/plan/run_plan_person.py`

## New dependencies included
- [ ] I have added the dependencies in `setup.py`

## Potential bug introduced
current operator order:
projector for property A -> filter for property A -> projector for property B -> filter for property B
If B is stateful and depends on A, e.g. B requires the history length of n of the A property to compute, however, since property A can be filtered, A property from some history frames that filtered out will not be saved into Projector B's buffer, leading to missing history property values to compute property B. 
