### PR TITLE
Fix setup requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ ColorDetect==1.6.0
 opencv-python==4.7.0.72
 loguru==0.7.0
 pandas==2.0.2
+cython_bbox==0.1.3
+tqdm==4.66.1
+lap==0.4.0

--- a/vqpy/operator/detector/models/torch/yolox.py
+++ b/vqpy/operator/detector/models/torch/yolox.py
@@ -11,12 +11,6 @@ from loguru import logger
 from vqpy.operator.detector.base import DetectorBase
 from vqpy.class_names.coco import COCO_CLASSES
 
-from yolox.data.data_augment import ValTransform
-from yolox.exp.build import get_exp
-from yolox.utils import postprocess
-from yolox.utils.model_utils import get_model_info
-
-
 class YOLOXDetector(DetectorBase):
     """The YOLOX detector for object detection"""
 
@@ -25,6 +19,12 @@ class YOLOXDetector(DetectorBase):
 
     def __init__(self, model_path, device="gpu", fp16=True):
         # TODO: start a new process handling this
+
+        from yolox.data.data_augment import ValTransform
+        from yolox.exp.build import get_exp
+        from yolox.utils import postprocess
+        from yolox.utils.model_utils import get_model_info
+
         exp = get_exp(None, "yolox_x")
         exp.test_conf = 0.3
         exp.nmsthre = 0.3

--- a/vqpy/operator/detector/models/torch/yolox.py
+++ b/vqpy/operator/detector/models/torch/yolox.py
@@ -11,6 +11,7 @@ from loguru import logger
 from vqpy.operator.detector.base import DetectorBase
 from vqpy.class_names.coco import COCO_CLASSES
 
+
 class YOLOXDetector(DetectorBase):
     """The YOLOX detector for object detection"""
 


### PR DESCRIPTION
## Why this change?

Current `requirements.txt` cannot set up the environment from stretch. This PR fixes it.

## What does this PR include?

- Add more package dependencies.
- Altered the implementation of `yolox` dependencies. Now we do not need to install `yolox` for running VQPy.

## User API changes

## How did I test the PR?

## New dependencies included
- I have added the dependencies in `setup.py`.
